### PR TITLE
Helpful project files && content suggestions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,25 @@
+# This file is a special npm configuration file.
+#
+# From npm docs:
+#
+#   The --global-style argument will cause
+#   npm to install the package into your
+#   local node_modules folder with the same
+#   layout it uses with the global node_modules
+#   folder. Only your direct dependencies
+#   will show in node_modules and everything
+#   they depend on will be flattened in their
+#   node_modules folders. This obviously will
+#   eliminate some deduping.
+#
+# t2-cli gives third party modules control over what
+# files and dependencies get deployed to a Tessel 2
+# by supporting .tesselignore and .tesselinclude files.
+# Ever since npm 3, dependency flattening has taken that
+# control away, since the rules in those files are
+# resolved relative to the third party module itself.
+# Forcing Tessel 2 project dependencies to install as
+# described above restores that control, ideally
+# producing smaller project bundles.
+
+global-style = true

--- a/.tesselinclude
+++ b/.tesselinclude
@@ -1,0 +1,6 @@
+# This file should list any files or directories you want included with the
+# T2 bundling and deployment process. This is handy for including
+# non-JavaScript assets, like HTML, CSS, and images, for use within your project.
+# .tesselinclude works the same as .npminclude
+# You DO NOT need to list node_modules or package.json
+# For more information, visit: https://tessel.io/docs/cli#usage

--- a/content/main.js
+++ b/content/main.js
@@ -13,7 +13,7 @@ ambient.on('ready', () => {
   // Get points of light data. The readings will happen every .5 seconds
   // The frequency can be updated by setting ambient.pollingFrequency
   ambient.on('light', (lightData) => {
-    const value = lightData.pop();
+    const value = lightData[0];
     console.log('Light level:', value.toFixed(8));
     reportLightLevel(value);
   });

--- a/content/main.js
+++ b/content/main.js
@@ -13,8 +13,9 @@ ambient.on('ready', () => {
   // Get points of light data. The readings will happen every .5 seconds
   // The frequency can be updated by setting ambient.pollingFrequency
   ambient.on('light', (lightData) => {
-    console.log('Light level:', lightData.toFixed(8));
-    reportLightLevel(lightData);
+    const value = lightData.pop();
+    console.log('Light level:', value.toFixed(8));
+    reportLightLevel(value);
   });
 });
 

--- a/content/main.js
+++ b/content/main.js
@@ -11,7 +11,11 @@ const ambient = ambientlib.use(tessel.port['A']);
 
 ambient.on('ready', () => {
   // Get points of light data. The readings will happen every .5 seconds
-  setInterval(() => getLightLevel, 500);
+  // The frequency can be updated by setting ambient.pollingFrequency
+  ambient.on('light', (lightData) => {
+    console.log('Light level:', lightData.toFixed(8));
+    reportLightLevel(lightData);
+  });
 });
 
 ambient.on('error', (err) => {
@@ -23,16 +27,8 @@ client.onDeviceMethod('toggleLED', () => {
   tessel.led[2].toggle();
 });
 
-function getLightLevel() {
-  ambient.getLightLevel((err, lightdata) => {
-    if (err) throw err;
-    console.log('Light level:', lightdata.toFixed(8));
-    reportLightLevel(lightdata);
-  });
-};
-
 function reportLightLevel(value) {
-  const data = JSON.stringify({light: value });
+  const data = JSON.stringify({ light: value });
   const message = new Message(data);
 
   console.log('Sending message: ' + message.getData());


### PR DESCRIPTION
This PR adds 2 files that are useful for Tessel projects, both included when running `t2 init`:

- `.npmrc`
- `.tesselinclude`

`content/main.js` has been updated to use the 'light' event ([Reference](https://www.npmjs.com/package/ambient-attx4#events)) to remove the custom polling logic.

It turns out the ambient module is the only one I don't own anymore (I'll need to order some more now), as a fair warning to probably test this before merging.